### PR TITLE
Persist activities to JSON file

### DIFF
--- a/data/activities.json
+++ b/data/activities.json
@@ -1,0 +1,56 @@
+{
+  "Chess Club": {
+    "description": "Learn strategies and compete in chess tournaments",
+    "schedule": "Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 12,
+    "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+  },
+  "Programming Class": {
+    "description": "Learn programming fundamentals and build software projects",
+    "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+    "max_participants": 20,
+    "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+  },
+  "Gym Class": {
+    "description": "Physical education and sports activities",
+    "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+    "max_participants": 30,
+    "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+  },
+  "Soccer Team": {
+    "description": "Join the school soccer team and compete in matches",
+    "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+    "max_participants": 22,
+    "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+  },
+  "Basketball Team": {
+    "description": "Practice and play basketball with the school team",
+    "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+  },
+  "Art Club": {
+    "description": "Explore your creativity through painting and drawing",
+    "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+  },
+  "Drama Club": {
+    "description": "Act, direct, and produce plays and performances",
+    "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+    "max_participants": 20,
+    "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+  },
+  "Math Club": {
+    "description": "Solve challenging problems and participate in math competitions",
+    "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+    "max_participants": 10,
+    "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+  },
+  "Debate Team": {
+    "description": "Develop public speaking and argumentation skills",
+    "schedule": "Fridays, 4:00 PM - 5:30 PM",
+    "max_participants": 12,
+    "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+  }
+}


### PR DESCRIPTION
This PR adds simple file-based persistence for activities.

Changes:
- Add `data/activities.json` with initial activity seed data.
- Update `src/app.py` to load activities from `data/activities.json` and save on signup/unregister.

Notes:
- This is a minimal, incremental step toward a proper DB migration (issue #15). It provides durable storage so restarts won't lose signups.
- Next steps: run quick validation, add tests, and migrate to a real DB (SQLite/Postgres/Prisma+MongoDB) as desired.

Checklist:
- [x] Add seed data file
- [x] Update API to load/save
- [ ] Add automated tests
- [ ] Consider safe write strategies / backups
